### PR TITLE
fix(workers): 修复在使用隐身模式时请求头携带默认请求头的问题

### DIFF
--- a/workers.js
+++ b/workers.js
@@ -228,7 +228,7 @@ async function handleProxyRequest(request, url, corsHeaders) {
     const headers = {};
     for (const [key, value] of request.headers.entries()) {
         if (key.startsWith('x-cfspider-header-')) {
-            headers[key.replace('x-cfspider-header-', '')] = value;
+            headers[key.replace('x-cfspider-header-', '').split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()).join('-')] = value;
         }
     }
     


### PR DESCRIPTION
将请求头名称统一为为首字母大写（Pascal-Case）的形式，避免在判断 `User-Agent` 时错误地添加默认请求头（fix violettoolssite/CFspider#2）